### PR TITLE
Add hover tooltip for map markers

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,14 @@
 .read-the-docs {
   color: #888;
 }
+
+.leaflet-tooltip {
+  background-color: #1f1f1f;
+  color: #faf9f6;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: monospace;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}

--- a/src/components/CampusMap.tsx
+++ b/src/components/CampusMap.tsx
@@ -47,10 +47,16 @@ const CampusMap = ({ routePath, focusLocationId }: CampusMapProps) => {
 
     // Add markers
     locations.forEach((loc) => {
-      L.marker([loc.latitude, loc.longitude])
-        .addTo(map)
-        .bindPopup(`<strong>${loc.name}</strong><br/>${loc.description}`);
+   L.marker([loc.latitude, loc.longitude])
+    .addTo(map)
+    .bindPopup(`<strong>${loc.name}</strong><br/>${loc.description}`)
+    .bindTooltip(`<span>${loc.name}</span>`, {
+      direction: "top",
+      offset: [0, -10],
+      opacity: 0.9,
+      sticky: true,
     });
+});
 
     mapRef.current = map;
 


### PR DESCRIPTION
## Summary
Added hover tooltips to map markers for better usability and quick location identification.

## Changes
- Integrated Leaflet `.bindTooltip()` with markers
- Tooltip displays location name on hover
- Maintained existing click popup behavior
- Improved hover experience with smooth interaction

## UI Preview
<img width="572" height="373" alt="Screenshot 2026-04-07 at 11 08 36 AM" src="https://github.com/user-attachments/assets/25fe8124-da98-40a8-8815-8034fca4003b" />

### Why
Previously, users had to click on markers to identify locations. This enhancement allows quick identification via hover, improving overall user experience.

Closes #10 