### PR TITLE
feat: add route loading indicator

### DIFF
--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,34 @@
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface LoadingIndicatorProps {
+  isLoading: boolean;
+}
+
+export const LoadingIndicator = ({ isLoading }: LoadingIndicatorProps) => {
+  const [shouldRender, setShouldRender] = useState(isLoading);
+
+  useEffect(() => {
+    if (isLoading) {
+      setShouldRender(true);
+    } else {
+      const timer = setTimeout(() => setShouldRender(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isLoading]);
+
+  if (!shouldRender) return null;
+
+  return (
+    <div 
+      className={`absolute inset-0 z-[60] flex items-center justify-center pointer-events-none transition-opacity duration-300 ${
+        isLoading ? "opacity-100" : "opacity-0"
+      }`}
+    >
+      <div className="flex items-center gap-2 bg-white px-4 py-2 rounded-md shadow-sm border animate-in fade-in duration-200">
+        <Loader2 className="h-4 w-4 animate-spin text-primary" />
+        <span className="text-sm font-medium text-slate-700 whitespace-nowrap">Calculating optimal route...</span>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,16 +5,23 @@ import CampusMap from "@/components/CampusMap";
 import RouteInfo from "@/components/RouteInfo";
 import { fetchRoute, type RouteResult } from "@/services/api";
 import { ChevronLeft } from "lucide-react";
+import { LoadingIndicator } from "@/components/LoadingIndicator";
 
 const Index = () => {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [routeResult, setRouteResult] = useState<RouteResult | null>(null);
   const [focusLocationId, setFocusLocationId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleRoute = useCallback(async (fromId: string, toId: string) => {
-    const result = await fetchRoute(fromId, toId);
-    setRouteResult(result);
-    if (result) setFocusLocationId(null);
+    setIsLoading(true);
+    try {
+      const result = await fetchRoute(fromId, toId);
+      setRouteResult(result);
+      if (result) setFocusLocationId(null);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
 
   const handleSelectLocation = useCallback((id: string) => {
@@ -58,6 +65,7 @@ const Index = () => {
         </button>
 
         <main className="flex-1 relative">
+          <LoadingIndicator isLoading={isLoading} />
           <CampusMap
             routePath={routeResult?.path ?? null}
             focusLocationId={focusLocationId}


### PR DESCRIPTION
## Related Issue
Closes #5 

---

## Description
Adds a centered loading indicator to provide clear visual feedback during route calculation. This resolves a UX gap where the application appeared unresponsive while awaiting API responses.

---

## Changes

### State Management
- Wrapped fetch logic with an `isLoading` state.
- Utilized a `finally` block to guarantee proper dismissal of the loading indicator.

### UI/UX
- Implemented an absolutely positioned **"Calculating"** pill.
- Ensured true center alignment without causing layout shifts.

### Performance
- Added `pointer-events-none` to the overlay.
- Allows continued map interaction during loading transitions.

### Styling
- Designed a theme-consistent white pill component.
- Included a spinning icon and subtle shadow for improved visibility and readability.

---

## Visuals

https://github.com/user-attachments/assets/8d6e0f60-fda3-401c-bfca-e8e19f070561

---

## Conclusion
Please let me know if any changes are required. If everything looks good, I’d appreciate a merge!